### PR TITLE
Add type annotations, remove unnecessary returns, remove unused imports.

### DIFF
--- a/src/main/scala/org/apache/spark/mllib/feature/FeatureSelectionUtils.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FeatureSelectionUtils.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.mllib.feature
 
-import scala.collection.mutable.ArrayBuilder
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.mllib.linalg._
+
+import scala.collection.mutable
 
 /**
  * Feature utils object for selector methods.
@@ -40,8 +40,8 @@ object FeatureSelectionUtils {
     features match {
       case v: SparseVector =>
         val newSize = filterIndices.length
-        val newValues = new ArrayBuilder.ofDouble
-        val newIndices = new ArrayBuilder.ofInt
+        val newValues = new mutable.ArrayBuilder.ofDouble
+        val newIndices = new mutable.ArrayBuilder.ofInt
         var i = 0
         var j = 0
         var indicesIdx = 0

--- a/src/main/scala/org/apache/spark/mllib/feature/InfoThCriterion.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/InfoThCriterion.scala
@@ -46,7 +46,7 @@ trait InfoThCriterion extends Serializable with Ordered[InfoThCriterion] {
   /**
    *  Compares the score of two criterions
    */
-  override def compare(that: InfoThCriterion) = {
+  override def compare(that: InfoThCriterion): Int = {
     this.score.compare(that.score)
   }
 
@@ -75,7 +75,7 @@ trait InfoThCriterion extends Serializable with Ordered[InfoThCriterion] {
  */
 class Mim extends InfoThCriterion {
 
-  override def score = relevance
+  override def score: Float = relevance
 
   override def init(relevance: Float): InfoThCriterion = {
     this.setRelevance(relevance)
@@ -92,7 +92,7 @@ class Mifs(val beta: Float = 0.0f) extends InfoThCriterion {
 
   var redundance: Float = 0.0f
 
-  override def score = relevance - redundance * beta
+  override def score: Float = relevance - redundance * beta
 
   override def init(relevance: Float): InfoThCriterion = {
     this.setRelevance(relevance)
@@ -115,7 +115,7 @@ class Jmi extends InfoThCriterion {
   var conditionalRedundance: Float = 0.0f
   var selectedSize: Int = 0
 
-  override def score = {
+  override def score: Float = {
     if (selectedSize != 0) {
       relevance - redundance / selectedSize + conditionalRedundance / selectedSize
     } else {
@@ -142,7 +142,7 @@ class Mrmr extends InfoThCriterion {
   var redundance: Float = 0.0f
   var selectedSize: Int = 0
 
-  override def score = {
+  override def score: Float = {
     if (selectedSize != 0) {
       relevance - redundance / selectedSize
     } else {

--- a/src/main/scala/org/apache/spark/mllib/feature/SelectorModel.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/SelectorModel.scala
@@ -18,10 +18,7 @@
 package org.apache.spark.mllib.feature
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.mllib.linalg.{ Vector, Vectors }
-import org.apache.spark.mllib.regression.LabeledPoint
-import org.apache.spark.mllib.stat.Statistics
-import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.linalg.Vector
 
 /**
  * :: Experimental ::


### PR DESCRIPTION
This PR removes most of the warnings on `intellij`

![image](https://user-images.githubusercontent.com/7232635/33287009-3feb4f70-d385-11e7-9c2e-799463cb3195.png)

* Added public type annotations according to the [scala style guidelines](https://blog.jetbrains.com/scala/2016/10/05/beyond-code-style/)
`All public methods should have explicit type annotations. Type inference may break encapsulation in these cases, because it depends on internal method and class details. Without an explicit type, a change to the internals of a method or val could alter the public API of the class without warning, potentially breaking client code. Explicit type annotations can also help to improve compile times.`

* Removed unused `import` statements

* Removed unnecessary `return` keywords

* Edited scala doc comments - changed `@result` to `@return`